### PR TITLE
Add L1 Block number to block message

### DIFF
--- a/evm/block_message.proto
+++ b/evm/block_message.proto
@@ -219,6 +219,9 @@ message TransactionHeader {
   bytes From = 15;
   AddressCode ToCode = 16;
   repeated AccessTuple AccessList = 17;
+
+  // only applicable on L2 chains
+  optional uint64 GasL1 = 18;
 }
 
 message Transaction {

--- a/evm/block_message.proto
+++ b/evm/block_message.proto
@@ -231,7 +231,7 @@ message Transaction {
 
 message Chain {
   bytes ChainId = 1;
-  string  Config = 2;
+  string Config = 2;
 }
 
 message BlockMessage {
@@ -241,5 +241,5 @@ message BlockMessage {
 
   repeated BlockHeader Uncles = 4;
   repeated Transaction Transactions = 5;
-
+  optional uint64 L1BlockNumber = 6;
 }

--- a/evm/block_message.proto
+++ b/evm/block_message.proto
@@ -234,6 +234,15 @@ message Chain {
   string Config = 2;
 }
 
+message L1MessageInfo {
+  uint32 Kind = 1;
+  bytes Poster = 2;
+  uint64 BlockNumber = 3;
+  uint64 Timestamp = 4;
+  optional bytes RequestId = 5;
+  optional bytes L1BaseFee = 6;
+}
+
 message BlockMessage {
   Chain Chain = 1;
   BlockHeader Header = 2;
@@ -241,5 +250,6 @@ message BlockMessage {
 
   repeated BlockHeader Uncles = 4;
   repeated Transaction Transactions = 5;
-  optional uint64 L1BlockNumber = 6;
+  optional BlockHeader L1Header = 6;
+  optional L1MessageInfo L1MessageInfo = 7;
 }


### PR DESCRIPTION
- Add optional `L1BlockHash` field to `BlockMessage`. Messages with this field are to be considered as blocks from L2.